### PR TITLE
feat(docker-compose): add Jenkins, Neo4j, and Redis containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3.8"
+
+services:
+  jenkins:
+    build:
+      context: ./docker
+      dockerfile: dockerfile
+    container_name: jenkins-container
+    ports:
+      - "8080:8080"
+      - "50000:50000"
+    environment:
+      - JAVA_OPTS=-Djenkins.install.runSetupWizard=false
+    volumes:
+      - jenkins_home:/var/jenkins_home
+    networks:
+      - pipeline_network
+
+  neo4j:
+    image: neo4j:latest
+    container_name: neo4j-container
+    ports:
+      - "7474:7474" 
+      - "7687:7687"
+    environment:
+      - NEO4J_AUTH=neo4j/strongpassword123
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+      - neo4j_import:/import
+      - neo4j_plugins:/plugins
+    networks:
+      - pipeline_network
+
+  redis:
+    image: redis:latest
+    container_name: redis-container
+    ports:
+      - "6379:6379" 
+    networks:
+      - pipeline_network
+
+networks:
+  pipeline_network:
+
+volumes:
+  jenkins_home:
+  neo4j_data:
+  neo4j_logs:
+  neo4j_import:
+  neo4j_plugins:

--- a/scripts/message.txt
+++ b/scripts/message.txt
@@ -1,6 +1,8 @@
-fix(project): Removing reports of tests
+feat(docker-compose): add Jenkins, Neo4j, and Redis containers  
 
-It was notified that the I
-commit the test reports and
-this should not have happened. 
-so It's been removed these files.
+Added a `docker-compose` configuration with three
+containers: Jenkins, built using a custom Dockerfile;
+Neo4j, a graph database; and Redis, a caching and
+messaging in-memory store. Successfully configured
+and launched all three containers, including build
+and deployment steps.


### PR DESCRIPTION
Added a `docker-compose` configuration with three
containers: Jenkins, built using a custom Dockerfile; Neo4j, a graph database; and Redis, a caching and
messaging in-memory store. Successfully configured and launched all three containers, including build and deployment steps.